### PR TITLE
[Fix] tsconfig path

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "baseUrl": "/Users/midudev/Dev/esland-web",
+    "baseUrl": ".",
     "paths": {
       "@/*": [
         "src/*"


### PR DESCRIPTION
VSC does not recognize `@` paths due this value has your static realpath in your computer to `/Users/midudev/Dev/esland-web`