### PR TITLE
[Fix] Error in replaceExtWithDot function

### DIFF
--- a/scripts/convert-all.ts
+++ b/scripts/convert-all.ts
@@ -5,7 +5,7 @@ import { rm } from 'node:fs/promises';
 
 const glob = new Glob('public/**/*.{jpg,jpeg,png}');
 
-const replaceExtWithDot = (newExtWithDot: string, { inFilePath }: { inFilePath: string }) => join(dirname(inFilePath), basename(extname(inFilePath))) + newExtWithDot;
+const replaceExtWithDot = (newExtWithDot: string, { inFilePath }: { inFilePath: string }) => join(dirname(inFilePath), basename(inFilePath, extname(inFilePath))) + newExtWithDot;
 const shouldRemove = (str: string = '') => str.toLowerCase().startsWith('rm');
 const remove = shouldRemove(process.argv[2]?.toLowerCase());
 

--- a/scripts/download-all-images.ts
+++ b/scripts/download-all-images.ts
@@ -1,6 +1,6 @@
 import { getAwardImageURL, getImageURL, getMobileAwardImageURL, getThumbURL } from "./src/all-images-urls-functions";
 import editionsInfo from '../public/archivo-page/editions-info.json';
-import { join, dirname, extname, basename } from 'node:path';
+import { join } from 'node:path';
 import { mkdir } from 'node:fs/promises';
 import sharp from 'sharp';
 


### PR DESCRIPTION
When I changed in my scripts the way I replace the extension in no webp files I forgot to add the basename. Important if you want to replace any file that is not webp currently.

Deleted non needed imports in `download-all-images` script.

🙏