### PR TITLE
Fix bug in menu mobile version

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -60,7 +60,7 @@ const i18n = getI18N({ currentLocale })
 </header>
 
 <script>
-  document.addEventListener('astro:after-swap', function () {
+  document.addEventListener("astro:after-swap", function () {
     const menuToggle = document.getElementById("menu-toggle")
     const mobileMenu = document.getElementById("mobile-menu")
     const menuIcon = document.getElementById("menu-icon")

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -60,7 +60,7 @@ const i18n = getI18N({ currentLocale })
 </header>
 
 <script>
-  document.addEventListener("DOMContentLoaded", function () {
+  document.addEventListener('astro:after-swap', function () {
     const menuToggle = document.getElementById("menu-toggle")
     const mobileMenu = document.getElementById("mobile-menu")
     const menuIcon = document.getElementById("menu-icon")


### PR DESCRIPTION
Hola,

📃 [Issue reference: Problemas con el MobileMenu](https://github.com/midudev/esland-web/issues/51)

Parece que el bug está relacionado con los ciclos de vida en las `astro transitions` cuando se produce un cambio de página. Si quitas las `ViewTransitions` verás que el menu funciona pero sin las transiciones, y si lo vuelves a poner, cuando haces cambio de página el menú deja de funcionar.

Quizás tú puedas dar una mejor solución Midu. Dejo aquí la directiva: [`astro:after-swap`](https://docs.astro.build/en/guides/view-transitions/#astroafter-swap)

Un saludo,
Pedro Reyes.

PD: gracias por el inmenso aporte de valor que haces a la comunidad Midu