### PR TITLE
Fix header mobile

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -60,7 +60,7 @@ const i18n = getI18N({ currentLocale })
 </header>
 
 <script>
-  document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener('astro:page-load', () => {
     const menuToggle = document.getElementById("menu-toggle")
     const mobileMenu = document.getElementById("mobile-menu")
     const menuIcon = document.getElementById("menu-icon")


### PR DESCRIPTION
Hola, 
https://github.com/midudev/esland-web/issues/51

Estaba viendo la página en mobile y me fije que el header no respondía al script cuando navegaba por la aplicación, esto me paso hace poco en un proyecto que hice hace poco y me dio el mismo problema. Lo que recomiendo es usar esto de la documentación  https://docs.astro.build/en/guides/view-transitions/#astropage-load 

Saludos a todos y espero que le sirva a Midu (Gracias por todo el aprendizaje) 


https://github.com/midudev/esland-web/assets/104796963/e6c411f1-7bdf-41ab-9879-41974fe1b8f5

