### PR TITLE
Fix responsive design of info page and archivo page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "fontsource",
+        "premiosesland"
+    ]
+}

--- a/src/components/Galeria.astro
+++ b/src/components/Galeria.astro
@@ -6,7 +6,7 @@ const limit = Object.assign({ "1": { maxPhotos: 73 }, "2": { maxPhotos: 104}})[e
 const { maxPhotos = 0 } = limit;
 ---
 
-<div class='grid grid-cols-3 max-w-6xl gap-8 mx-auto py-20' id='gallery'>
+<div class='grid lg:grid-cols-3 grid-cols-2 max-w-6xl lg:gap-8 gap-4 lg:mx-auto mx-4 py-20' id='gallery'>
   {
     Array.from({ length: maxPhotos }).map((_, i) => (
       <a

--- a/src/components/pages/Archivo.astro
+++ b/src/components/pages/Archivo.astro
@@ -13,7 +13,7 @@ const { currentLocale } = Astro
 
 <Layout title="Archivo" description="Archivo">
   <HeroContainer img="/archivo-background.webp">
-    <h1 class="text-6xl uppercase mb-20 font-tomaso tracking-widest">
+    <h1 class="lg:text-6xl text-4xl text-center uppercase mb-20 font-tomaso tracking-widest">
       Ediciones anteriores
     </h1>
 

--- a/src/components/pages/Info.astro
+++ b/src/components/pages/Info.astro
@@ -1,7 +1,7 @@
 ---
-import Layout from '@/layouts/Layout.astro'
-import HeroContainer from '@/components/HeroContainer.astro'
 import Footer from '@/components/Footer.astro'
+import HeroContainer from '@/components/HeroContainer.astro'
+import Layout from '@/layouts/Layout.astro'
 
 import { getI18N } from '@/i18n'
 
@@ -14,7 +14,7 @@ const i18n = getI18N({ currentLocale })
   description="Los Premios ESLAND son una iniciativa privada promovida por el célebre streamer TheGrefg y buscan apoyar y reconocer la creación de contenido en el ámbito hispanohablante."
 >
   <HeroContainer img="/info-background.webp">
-    <h1 class="text-6xl uppercase font-tomaso tracking tracking-widest">
+    <h1 class="lg:text-6xl text-5xl text-center uppercase font-tomaso tracking tracking-widest">
       {i18n.INFO_TITLE}
     </h1>
   </HeroContainer>


### PR DESCRIPTION
I changed the title that was causing the page to overflow and switched the number of columns from 3 to 2.
![Captura de pantalla 2024-01-06 161948](https://github.com/midudev/esland-web/assets/88586253/ae5faa7d-9550-46da-8990-2be055405d9f)
![Captura de pantalla 2024-01-06 162928](https://github.com/midudev/esland-web/assets/88586253/7afc01e1-525a-4700-9408-421ee2477598)

On the info page, all I've done is change the size of the title and center it to match the rest of the pages.
![Captura de pantalla 2024-01-06 164447](https://github.com/midudev/esland-web/assets/88586253/af37f3da-1ffa-4c1e-bbcf-04e3b1fbec2d)
![Captura de pantalla 2024-01-06 164429](https://github.com/midudev/esland-web/assets/88586253/b2a32a6d-653e-4619-9e1c-8334afa1d5f9)
