### PR TITLE
Added the feature to lock scroll when opening the mobile menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -77,6 +77,7 @@ const i18n = getI18N({ currentLocale })
     menuToggle.addEventListener("click", function () {
       mobileMenu.classList.toggle("hidden")
       mobileMenu.classList.toggle("flex")
+			document.body.classList.toggle('overflow-hidden')
       menuIcon.textContent = menuIcon.textContent === "☰" ? "✕" : "☰"
     })
   })

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -77,7 +77,7 @@ const i18n = getI18N({ currentLocale })
     menuToggle.addEventListener("click", function () {
       mobileMenu.classList.toggle("hidden")
       mobileMenu.classList.toggle("flex")
-			document.body.classList.toggle('overflow-hidden')
+      document.body.classList.toggle('overflow-hidden')
       menuIcon.textContent = menuIcon.textContent === "☰" ? "✕" : "☰"
     })
   })


### PR DESCRIPTION
Se agregó la función de bloquear scroll al abrir el menú mobile usando js y la clase `overflow-hidden` de TailwindCSS
[screen-capture.webm](https://github.com/midudev/esland-web/assets/35277540/20901e22-3c4b-490a-97c2-b8748c3448ce)
