### PR TITLE
Fix translation links in the header

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,6 +5,7 @@ import Button from "./Button.astro"
 import LanguageSelector from "./LanguageSelector.astro"
 
 const { currentLocale } = Astro
+const currentLocalePage = currentLocale === "es" ? "" : "/ca";
 const i18n = getI18N({ currentLocale })
 ---
 
@@ -23,9 +24,9 @@ const i18n = getI18N({ currentLocale })
     <nav
       class="hidden md:flex flex-grow lg:basis-0 w-full gap-x-8 text-lg md:justify-center font-medium items-center"
     >
-      <a class="text__glowing" href="/vota">{i18n.HEADER_VOTE}</a>
-      <a class="text__glowing" href="/info">{i18n.HEADER_INFO}</a>
-      <a class="text__glowing" href="/archivo">{i18n.HEADER_ARCHIVE}</a>
+      <a class="text__glowing" href={`${currentLocalePage}/vota`}>{i18n.HEADER_VOTE}</a>
+      <a class="text__glowing" href={`${currentLocalePage}/info`}>{i18n.HEADER_INFO}</a>
+      <a class="text__glowing" href={`${currentLocalePage}/archivo`}>{i18n.HEADER_ARCHIVE}</a>
       <LanguageSelector />
     </nav>
 
@@ -54,8 +55,8 @@ const i18n = getI18N({ currentLocale })
     id="mobile-menu"
     class="bg-[#151a36]/90 -translate-y-full transition-transform md:hidden w-full flex flex-col items-center text-center text-2xl fixed top-0 left-0 right-0 h-dvh place-content-center"
   >
-    <a class="my-4 text__glowing" href="/info">{i18n.HEADER_INFO}</a>
-    <a class="my-4 text__glowing" href="/archivo">{i18n.HEADER_ARCHIVE}</a>
+    <a class="my-4 text__glowing" href={`${currentLocalePage}/info`}>{i18n.HEADER_INFO}</a>
+    <a class="my-4 text__glowing" href={`${currentLocalePage}/archivo`}>{i18n.HEADER_ARCHIVE}</a>
     <Button
       class="my-4 whitespace-nowrap text-center lg:hidden lg:text-base"
       url="https://www.youtube.com/watch?v=O43x26hiolw"


### PR DESCRIPTION
En este commit se arregla el error en el que al dirigirte a otra pagina, por ejemplo archivo. (con el idioma en catalan) te devolvía al idioma español y no se mantenían los cambios en el idioma.