### PR TITLE
fix: palmares types

### DIFF
--- a/src/components/Palmares.astro
+++ b/src/components/Palmares.astro
@@ -10,16 +10,17 @@ interface PalmaresProps {
   foto1: string
   foto2: string
   comunidad1: number
-  comundidad2: number
-  streamers1: number
   comunidad2: number
+  streamers1: number
   total1: number
   streamers2: number
   total2: number
-  finalista?: string
+  finalista: string
 }
 
 let datosSeleccionados = palmares.find((palmar) => palmar.edition === edicion)
+const palmaresSelected: PalmaresProps = datosSeleccionados?.info[index] as
+PalmaresProps
 const {
   comunidad1,
   comunidad2,
@@ -31,7 +32,7 @@ const {
   streamers2,
   total1,
   total2,
-}: PalmaresProps = datosSeleccionados?.info[index]
+} = palmaresSelected
 ---
 
 <section class="flex flex-col gap-4 pt-6 justify-center items-center">


### PR DESCRIPTION
Arreglo del tipado en [`palmares.astro`](https://github.com/midudev/esland-web/blob/f65b8083d5d0fac19ea54553a02b67b663846576/src/components/Palmares.astro)

![image](https://github.com/midudev/esland-web/assets/35697365/5c79e83d-2547-4555-835f-91fd9c38c844)

Al correr la build:

- Actual:
![image](https://github.com/midudev/esland-web/assets/35697365/b19239af-2b13-44b2-8831-e29c972a40ac)

- Con los cambios
![image](https://github.com/midudev/esland-web/assets/35697365/0b44ac02-1b89-4a37-81f0-a3da6a8dc766)
