### PR TITLE
[FIX] Palmares.astro type error

### DIFF
--- a/src/components/Palmares.astro
+++ b/src/components/Palmares.astro
@@ -2,24 +2,21 @@
 import StreamerCard from "../components/StreamerCard.astro"
 import palmares from "../../public/archivo-page/editions-info.json"
 // ! la variable edicion es recibida desde ArchivoPage
-const { edicion } = Astro.props
-let index = 3
-interface PalmaresProps {
-  categoria: string
-  ganador: string
-  foto1: string
-  foto2: string
-  comunidad1: number
-  comunidad2: number
-  streamers1: number
-  comunidad2: number
-  total1: number
-  streamers2: number
-  total2: number
-  finalista?: string
+interface Props {
+  edicion: string
 }
 
-let datosSeleccionados = palmares.find((palmar) => palmar.edition === edicion)
+const { edicion } = Astro.props
+let index = 3
+
+let datosSeleccionados = palmares.find(
+  (palmar) => palmar.edition === edicion
+)
+
+if (!datosSeleccionados) {
+  return
+}
+
 const {
   comunidad1,
   comunidad2,
@@ -31,7 +28,7 @@ const {
   streamers2,
   total1,
   total2,
-}: PalmaresProps = datosSeleccionados?.info[index]
+} = datosSeleccionados?.info[index]
 ---
 
 <section class="flex flex-col gap-4 pt-6 justify-center items-center">


### PR DESCRIPTION
- Podemos remover `PalmaresProps` y dejar que TS haga su magia con el type inference
- En caso de que `find` no encuentre la edición correcta ocurriría un error en runtime, de modo que podemos hacer un early return para prevenir un crash si manualmente ponemos una edición incorrecta
- Añadí las props del componente por salud mental 🥵

```sh
pnpm build result:

Result (67 files): 
- 0 errors
- 0 warnings
- 8 hints
```