### PR TITLE
Fix: header vertical padding

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,7 +11,7 @@ const { currentLocale } = Astro
 const i18n = getI18N({ currentLocale })
 ---
 
-<header id="header-nav" class="fixed top-0 z-50 w-full px-6 pt-4">
+<header id="header-nav" class="fixed top-0 z-50 w-full px-6 py-4">
   <div class="mx-auto flex max-w-7xl items-center justify-between">
     <div class="flex flex-grow basis-0 z-50">
       <HeaderLink


### PR DESCRIPTION
The header's content is centered, adding padding at the bottom and not only at the top

Before
![image](https://github.com/midudev/esland-web/assets/50101944/d7ed4cf8-3a7d-47dc-961f-fc7098c8722e)

After
![image](https://github.com/midudev/esland-web/assets/50101944/a2ddf1b5-8aed-4a5a-a34e-e99649a63148)

