### PR TITLE
Make 'Palmarés' section responsive

### DIFF
--- a/src/components/Palmares.astro
+++ b/src/components/Palmares.astro
@@ -31,10 +31,10 @@ const {
 } = datosSeleccionados?.info[index]
 ---
 
-<section class="flex flex-col gap-4 pt-6 justify-center items-center">
-  <h1 class="text-6xl uppercase font-tomaso">Palmarés</h1>
-  <div class="flex gap-44 h-fit justify-center items-center">
-    <div class="flex flex-col min-w-[500px] gap-1">
+<section class="max-w-6xl mx-auto flex flex-col gap-4 pt-6 justify-center items-center px-20">
+  <h2 class="text-4xl lg:text-6xl text-center mb-10 lg:mb-20 uppercase font-tomaso">Palmarés</h2>
+  <div class="flex flex-col lg:flex-row gap-10">
+    <div class="flex flex-col gap-1">
       {
         palmares.map((item) => {
           if (item.edition === edicion) {


### PR DESCRIPTION
Application of Tailwind CSS class settings to specifically improve the mobile layout of the "Palmarés" section, for better visualization on smaller screens.

**Before:**

![image](https://github.com/midudev/esland-web/assets/22538431/2bd58f67-cc76-4e36-b53a-b2ca40420fbb)

**After:**

![image](https://github.com/midudev/esland-web/assets/22538431/76a2b55a-6a22-4ebd-8059-703234310479) ![image](https://github.com/midudev/esland-web/assets/22538431/62439438-6f95-47f2-9815-a815cb17452f)
