### PR TITLE
fix: add spaces on voting page for mobile screens

### DIFF
--- a/src/components/pages/Vote.astro
+++ b/src/components/pages/Vote.astro
@@ -20,7 +20,7 @@ import Button from "@/components/Button.astro"
       alt="ESLAND cover"
     />
 
-    <div class="mx-auto flex flex-col max-w-7xl pt-40">
+    <div class="mx-auto px-6 flex flex-col max-w-7xl pt-40">
       <h1
         class="uppercase mb-10 text-left text-3xl lg:text-5xl font-bold tracking-wider leading-loose max-w-xl text-balance"
       >


### PR DESCRIPTION
# Before

![image](https://github.com/midudev/esland-web/assets/4429864/6e3dfe88-6844-46bf-b2df-e354f993dda5)

# After

![image](https://github.com/midudev/esland-web/assets/4429864/9f2e2bb3-605c-46f4-8fe0-c0e2bdd56e12)

