### PR TITLE
fix: add spaces on the voting page for mobile screens

### DIFF
--- a/src/components/pages/Vote.astro
+++ b/src/components/pages/Vote.astro
@@ -28,7 +28,7 @@ const bkg = session ? "vote-system-bkg.webp" : "vota-bkg.webp"
 
     {
       !session && (
-        <div class="mx-auto flex flex-col max-w-7xl pt-40">
+        <div class="mx-auto flex flex-col max-w-7xl px-6 pt-40">
           <h1 class="uppercase mb-10 text-left text-3xl lg:text-5xl font-bold tracking-wider leading-loose max-w-xl text-balance">
             Las votaciones ya están aquí
           </h1>


### PR DESCRIPTION
Add spaces on the voting page for mobile screens

## Before
![image](https://github.com/midudev/esland-web/assets/4429864/f35dcfd7-2c69-40d3-a6ed-06d711170237)

## After
![image](https://github.com/midudev/esland-web/assets/4429864/c192badd-fee8-481e-98e8-c835642a1435)
