### PR TITLE
Change all the imports to use Astro Alias

### DIFF
--- a/src/components/Bento.astro
+++ b/src/components/Bento.astro
@@ -1,5 +1,5 @@
 ---
-import BentoItem from "./BentoItem.astro"
+import BentoItem from "@/components/BentoItem.astro"
 import { getI18N } from "@/i18n/"
 
 const { currentLocale } = Astro

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
-import Logo from "./Logo.astro"
-import { getI18N } from "../i18n/"
-import Link from "./Link.astro"
+import Logo from "@/components/Logo.astro"
+import { getI18N } from "@/i18n/"
+import Link from "@/components/Link.astro"
 
 const { currentLocale } = Astro
 const i18n = getI18N({ currentLocale })

--- a/src/components/Galeria.astro
+++ b/src/components/Galeria.astro
@@ -1,7 +1,7 @@
 ---
 import "photoswipe/style.css"
 import editionsInfo from "@/data/meta-gallery.json"
-import Button from "./Button.astro"
+import Button from "@/components/Button.astro"
 
 const offset = 10
 const { edicion } = Astro.props

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,11 +1,11 @@
 ---
-import Logo from "./Logo.astro"
-import { getI18N } from "../i18n/"
-import Button from "./Button.astro"
+import Logo from "@/components/Logo.astro"
+import { getI18N } from "@/i18n/"
+import Button from "@/components/Button.astro"
 import MenuIcon from "@/components/icons/Menu.astro"
 import CloseIcon from "@/components/icons/Close.astro"
-import LanguageSelector from "./LanguageSelector.astro"
-import HeaderLink from "./HeaderLink.astro"
+import LanguageSelector from "@/components/LanguageSelector.astro"
+import HeaderLink from "@/components/HeaderLink.astro"
 
 const { currentLocale } = Astro
 const i18n = getI18N({ currentLocale })

--- a/src/components/InfoKitPrensa.astro
+++ b/src/components/InfoKitPrensa.astro
@@ -1,6 +1,6 @@
 ---
 import { getI18N } from "@/i18n"
-import InfoKitPrensaItem from "./InfoKitPrensaItem.astro"
+import InfoKitPrensaItem from "@/components/InfoKitPrensaItem.astro"
 const { currentLocale } = Astro
 const i18n = getI18N({ currentLocale })
 ---

--- a/src/components/Intro.astro
+++ b/src/components/Intro.astro
@@ -1,7 +1,7 @@
 ---
-import Logo from "./Logo.astro"
+import Logo from "@/components/Logo.astro"
 
-import { getI18N } from "../i18n/"
+import { getI18N } from "@/i18n/"
 
 const { currentLocale } = Astro
 const i18n = getI18N({ currentLocale })

--- a/src/components/Numeros.astro
+++ b/src/components/Numeros.astro
@@ -1,6 +1,6 @@
 ---
-import { CountUp } from "./CountUp"
-import NumerosItem from "./NumerosItem.astro"
+import { CountUp } from "@/components/CountUp"
+import NumerosItem from "@/components/NumerosItem.astro"
 
 const { i18n } = Astro.props
 ---

--- a/src/components/Palmares.astro
+++ b/src/components/Palmares.astro
@@ -1,5 +1,5 @@
 ---
-import StreamerCard from "../components/StreamerCard.astro"
+import StreamerCard from "@/components/StreamerCard.astro"
 import palmares from "../../public/archivo-page/editions-info.json"
 
 interface Props {

--- a/src/components/Video.astro
+++ b/src/components/Video.astro
@@ -1,7 +1,7 @@
 ---
 import { getI18N } from "@/i18n/"
-import Button from "./Button.astro"
-import Logo from "./Logo.astro"
+import Button from "@/components/Button.astro"
+import Logo from "@/components/Logo.astro"
 
 const { currentLocale } = Astro
 const i18n = getI18N({ currentLocale })

--- a/src/components/pages/Archivo.astro
+++ b/src/components/pages/Archivo.astro
@@ -1,12 +1,12 @@
 ---
 import Layout from "@/layouts/Layout.astro"
 import HeroContainer from "@/components/HeroContainer.astro"
-import Button from "../Button.astro"
-import Palmares from "../Palmares.astro"
+import Button from "@/components/Button.astro"
+import Palmares from "@/components/Palmares.astro"
 import { getI18N } from "@/i18n"
-import Numeros from "../Numeros.astro"
-import Galeria from "../Galeria.astro"
-import Footer from "../Footer.astro"
+import Numeros from "@/components/Numeros.astro"
+import Galeria from "@/components/Galeria.astro"
+import Footer from "@/components/Footer.astro"
 const edicion = "2"
 const { currentLocale } = Astro
 const i18n = getI18N({ currentLocale })

--- a/src/components/pages/Info.astro
+++ b/src/components/pages/Info.astro
@@ -3,7 +3,7 @@ import Footer from "@/components/Footer.astro"
 import HeroContainer from "@/components/HeroContainer.astro"
 import Layout from "@/layouts/Layout.astro"
 
-import InfoKitPrensa from "../InfoKitPrensa.astro"
+import InfoKitPrensa from "@/components/InfoKitPrensa.astro"
 
 import { getI18N } from "@/i18n"
 const { currentLocale } = Astro

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,5 +1,5 @@
-import catalan from './ca.json'
-import spanish from './es.json'
+import catalan from '@/i18n/ca.json'
+import spanish from '@/i18n/es.json'
 
 const LANGUAGES = {
   CATALAN: 'ca',

--- a/src/pages/ca/index.astro
+++ b/src/pages/ca/index.astro
@@ -1,5 +1,5 @@
 ---
-import App from "../../components/pages/App.astro"
+import App from "@/components/pages/App.astro"
 ---
 
 <App />


### PR DESCRIPTION
Some of the imports were using [Astro Aliases](https://docs.astro.build/es/guides/aliases/) and some weren't.  
This PR made all the files use the Astro Aliases to:
- Make the code more legible
- Make all the imports easy to copy into other files without having to worry if they are or not in the same path