### PR TITLE
Add privacidad page (es/ca)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -80,7 +80,7 @@ const i18n = getI18N({ currentLocale })
             </li>
             <li>
               <a
-                href="https://premiosesland.com/privacidad"
+                href="/privacidad"
                 class="hover:underline hover:text-primary duration-300"
                 >{i18n.FOOTER.LEGAL.PRIVACY}</a
               >

--- a/src/components/pages/Privacidad.astro
+++ b/src/components/pages/Privacidad.astro
@@ -1,0 +1,105 @@
+---
+import Layout from "@/layouts/Layout.astro"
+import { getI18N } from "@/i18n"
+
+const { currentLocale } = Astro
+const i18n = getI18N({ currentLocale })
+const HEADING_STYLES =
+  "mx-auto mt-16 mb-4 text-wrap text-4xl font-semibold tracking-wide uppercase"
+const SECTION_STYLES = 
+  "max-w-5xl mx-auto my-10 text-pretty px-6 text-left text-lg leading-relaxed sm:px-20"
+---
+
+<Layout title={i18n.SEO.INFO_TITLE} description={i18n.SEO.INFO_DESCRIPTION}>
+  <main class="py-8">
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.POLICY.TITLE}</h2>
+      <p>{i18n.PRIVACY.POLICY.DESCRIPTION_1}</p>
+      <p>{i18n.PRIVACY.POLICY.DESCRIPTION_2}</p>
+      <p>{i18n.PRIVACY.POLICY.DESCRIPTION_3}</p>
+      <p>{i18n.PRIVACY.POLICY.DESCRIPTION_4}</p>
+      <p>{i18n.PRIVACY.POLICY.DESCRIPTION_5}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.RESPONSIBLE.TITLE}</h2>
+      <p>{i18n.PRIVACY.RESPONSIBLE.DESCRIPTION_1}</p>
+      <p>{i18n.PRIVACY.RESPONSIBLE.DESCRIPTION_2}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.DEFINITIONS.TITLE}</h2>
+      <p>{i18n.PRIVACY.DEFINITIONS.DESCRIPTION}</p>
+      <ul>
+        <li><p>{i18n.PRIVACY.DEFINITIONS.ITEM_1}</p></li>
+        <li><p>{i18n.PRIVACY.DEFINITIONS.ITEM_2}</p></li>
+        <li><p>{i18n.PRIVACY.DEFINITIONS.ITEM_3}</p></li>
+        <li><p>{i18n.PRIVACY.DEFINITIONS.ITEM_4}</p></li>
+        <li><p>{i18n.PRIVACY.DEFINITIONS.ITEM_5}</p></li>
+      </ul>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.PURPOSE.TITLE}</h2>
+      <p>{i18n.PRIVACY.PURPOSE.DESCRIPTION_1}</p>
+      <p>{i18n.PRIVACY.PURPOSE.DESCRIPTION_2}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.PERSONAL_DATA.TITLE}</h2>
+      <p>{i18n.PRIVACY.PERSONAL_DATA.DESCRIPTION_1}</p>
+      <p>{i18n.PRIVACY.PERSONAL_DATA.DESCRIPTION_2}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.LEGITIMACY.TITLE}</h2>
+      <p>{i18n.PRIVACY.LEGITIMACY.DESCRIPTION_1}</p>
+      <p>{i18n.PRIVACY.LEGITIMACY.DESCRIPTION_2}</p>
+      <p>{i18n.PRIVACY.LEGITIMACY.DESCRIPTION_3}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.PRESERVATION.TITLE}</h2>
+      <p>{i18n.PRIVACY.PRESERVATION.DESCRIPTION_1}</p>
+      <p>{i18n.PRIVACY.PRESERVATION.DESCRIPTION_2}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.COMMUNICATION.TITLE}</h2>
+      <p>{i18n.PRIVACY.COMMUNICATION.DESCRIPTION_1}</p>
+      <p>{i18n.PRIVACY.COMMUNICATION.DESCRIPTION_2}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.USER_RIGHTS.TITLE}</h2>
+      <p>{i18n.PRIVACY.USER_RIGHTS.DESCRIPTION_1}</p>
+      <ul class="list-disc">
+        <li><p>{i18n.PRIVACY.USER_RIGHTS.ITEM_1}</p></li>
+        <li><p>{i18n.PRIVACY.USER_RIGHTS.ITEM_2}</p></li>
+        <li><p>{i18n.PRIVACY.USER_RIGHTS.ITEM_3}</p></li>
+        <li><p>{i18n.PRIVACY.USER_RIGHTS.ITEM_4}</p></li>
+        <li><p>{i18n.PRIVACY.USER_RIGHTS.ITEM_5}</p></li>
+      </ul>
+      <p>{i18n.PRIVACY.USER_RIGHTS.DESCRIPTION_2}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.THIRD_PARTY_DOMAIN_LINKS.TITLE}</h2>
+      <p>{i18n.PRIVACY.THIRD_PARTY_DOMAIN_LINKS.DESCRIPTION}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.SOCIALS.TITLE}</h2>
+      <p>{i18n.PRIVACY.SOCIALS.DESCRIPTION_1}</p>
+      <p>{i18n.PRIVACY.SOCIALS.DESCRIPTION_2}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.COOKIES.TITLE}</h2>
+      <p>{i18n.PRIVACY.COOKIES.DESCRIPTION_1}</p>
+      <p>{i18n.PRIVACY.COOKIES.DESCRIPTION_2}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`></h2>
+      <p> </p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.INTERNATIONAL_TRANSFERS.TITLE}</h2>
+      <p>{i18n.PRIVACY.INTERNATIONAL_TRANSFERS.DESCRIPTION}</p>
+    </section>
+    <section class=`${SECTION_STYLES}`>
+      <h2 class=`${HEADING_STYLES}`>{i18n.PRIVACY.MODIFICATIONS.TITLE}</h2>
+      <p>{i18n.PRIVACY.MODIFICATIONS.DESCRIPTION}</p>
+      <p><em>{i18n.PRIVACY.MODIFICATIONS.LAST_UPDATE}</em></p>
+    </section>
+  </main>
+</Layout>

--- a/src/i18n/ca.json
+++ b/src/i18n/ca.json
@@ -189,6 +189,89 @@
       ]
     }
   },
+  "PRIVACY": {
+    "POLICY": {
+      "TITLE": "Política de privacitat",
+      "DESCRIPTION_1": "Ens complau que visiteu la web oficial de PREMIS ESLAND www.premiosesland.com (d'ara endavant, Lloc Web) i agraïm el vostre interès.",
+      "DESCRIPTION_2": "UBIQ S.L.U (d'ara endavant, UBIQ) té el ferm compromís de complir amb la legislació vigent en matèria de protecció de dades personals per garantir la privadesa, el secret i la seguretat de les dades personals dels Usuaris aplicant mesures tècniques i organitzatives apropiades a aquest efecte.",
+      "DESCRIPTION_3": "La present Política de Privadesa té per objecte informar els Usuaris sobre el tractament que UBIQ fa de les dades personals que l'Usuari faciliti en accedir, navegar i utilitzar els serveis que s'ofereixen al Lloc Web, així com de les mesures de seguretat adoptades, de l'exercici dels drets dels Usuaris i de la forma de contacte.",
+      "DESCRIPTION_4": "Les dades personals només seran obtingudes per UBIQ per al seu tractament, quan siguin adequades, pertinents i no excessives en relació amb l'àmbit i les finalitats determinades, explícites i legítimes per a les quals s'hagin obtingut.",
+      "DESCRIPTION_5": "A continuació, compliment amb la normativa vigent en matèria de protecció de dades personals proporcionem als Usuaris la informació següent:"
+    },
+    "RESPONSIBLE": {
+      "TITLE": "Responsable del tractament",
+      "DESCRIPTION_1": "UBIQ S.L.U (d'ara endavant, UBIQ) societat andorrana amb NRT L-718097-X, amb domicili social al carrer Josep Viladomat, 4, Ed Sogas, 1-1 AD700 Escaldes Engordany (Andorra), inscrita al Registre de Societats del Govern d'Andorra amb núm. 23023, amb correu electrònic [info@ubiq.ad………….], és la titular de la pàgina web www.premiosesland.com (d'ara endavant, Lloc Web).",
+      "DESCRIPTION_2": "Els Usuaris poden contactar amb el Responsable del Tractament a través de la següent adreça de correu electrònic: info@ubiq.ad"
+    },
+    "DEFINITIONS": {
+      "TITLE": "Definicions",
+      "DESCRIPTION": "A l'efecte de la present Política, els termes següents tindran el significat que s'indica a continuació:",
+      "ITEM_1": "“Dades Personals”: tota informació sobre una persona física identificada o identificable. Es considera persona física identificable tota persona la identitat de la qual es pugui determinar, directament o indirectament, mitjançant un identificador.",
+      "ITEM_2": "“Responsable del Tractament”: Persona física o jurídica, autoritat pública, servei o un altre organisme que, sol o juntament amb altres, determini els fins i mitjans del tractament de dades.",
+      "ITEM_3": "“Encarregat del Tractament”: Persona física o jurídica, autoritat pública, servei o un altre organisme que tracti dades personals per compte del responsable del tractament.",
+      "ITEM_4": "“Interessat-Usuari”: Tota persona física identificada o identificable les dades personals de la qual siguin objecte de tractament.",
+      "ITEM_5": "“Tractament de dades”: Qualsevol operació o conjunt d'operacions realitzades sobre dades personals o conjunts de dades personals, ja sigui per procediments automatitzats o no, com la recollida, registre, organització, estructuració, conservació, adaptació o modificació , extracció, consulta, utilització, comunicació per transmissió, difusió o qualsevol altra forma d'habilitació d'accés, confrontació o interconnexió, limitació, supressió o destrucció."
+    },
+    "PURPOSE": {
+      "TITLE": "Finalitat del tractament",
+      "DESCRIPTION_1": "Gestionar les sol·licituds d'informació rebudes a través de la funció de “Contacte” de la Web. Gestionar les votacions dels PREMIS ESLAND realitzades pels Usuaris del Lloc Web (identificació, validació i recompte de vots). Fins estadístiques de participació i resultats de les votacions als PREMIS ESLAND -per donar compliment a aquesta finalitat les dades personals seran objecte d'un procés d'anonimització- Per poder participar com a jurat als PREMIS ESLAND, els Usuaris hauran de prémer “Identifica't i Vota” i seran redireccionats a la web de Twitch (www.twitch.tv) on hauran de disposar d'un compte obert en aquesta plataforma de streaming Quan l'Usuari des del seu compte premi “Autoritzar” estarà manifestant que ha llegit i que accepta la Política de Privadesa de www.premiosesland.com A continuació, l'Usuari podrà seleccionar les seves preferències de vot entre les diferents categories definides per Streamers i continguts seguint les indicacions del Lloc Web i una vegada seleccionats els seus vots haurà de prémer “Enviar Els meus Vots” . Les votacions i la identitat de l'Usuari es registraran a la base de dades de UBIQ. La identitat de l'Usuari es registrarà mitjançant un codi hash -algorisme matemàtic- (pseudonimitzat).",
+      "DESCRIPTION_2": "Twitch Interactive, Inc. propietària de www.twitch.tv actua com a proveïdor dels serveis de validació i verificació de la identitat dels Usuaris que voten per evitar el frau en el procés de votació."
+    },
+    "PERSONAL_DATA": {
+      "TITLE": "Categoria de dades personals",
+      "DESCRIPTION_1": "La categoria de dades que tracta UBIQ al Lloc Web són:",
+      "DESCRIPTION_2": "Correu electrònic en funció de Contacte. Dades identificatives: Identificació de l'Usuari mitjançant un codi hash -algorisme matemàtic-. UBIQ no accedeix a les dades del compte que els Usuaris tenen a www.twitch.tv."
+    },
+    "LEGITIMACY": {
+      "TITLE": "Base de legitimació",
+      "DESCRIPTION_1": "La base de legitimació per gestionar les comunicacions que es rebin a través de la funció “Contacte” és l'interès legítim d'UBIQ.",
+      "DESCRIPTION_2": "La base de legitimació del tractament de les dades personals dels Usuaris que participen als PREMIS ESLAND és el consentiment exprés atorgat en participar com a jurat i l'interès legítim d'UBIQ en la gestió dels esdeveniments que organitzi i en la gestió dels PREMIS ESLAND.",
+      "DESCRIPTION_3": "L'Usuari podrà revocar el consentiment en qualsevol moment. No obstant, el tractament sobre les dades personals realitzat amb anterioritat a la revocació del consentiment serà lícit."
+    },
+    "PRESERVATION": {
+      "TITLE": "Conservació de les dades",
+      "DESCRIPTION_1": "Les dades es conservaran durant el termini estrictament necessari per donar compliment a la finalitat per a la qual van ser recollides. No obstant això, UBIQ podrà conservar les dades per a la posada a disposició de les autoritats competents o per fer front a possibles reclamacions, en aquest cas les dades es conservaran bloquejades fins a la finalització dels terminis de prescripció, moment en què seran eliminats amb les mesures de seguretat adequades.",
+      "DESCRIPTION_2": "Finalitzat el termini de conservació, les dades personals podran ser objecte d'un procés d'anonimització per a fins estadístiques dels PREMIS ESLAND."
+    },
+    "COMMUNICATION": {
+      "TITLE": "Comunicació de dades",
+      "DESCRIPTION_1": "UBIQ no cedirà a tercers les dades facilitades pels Usuaris del Lloc Web, llevat de consentiment previ i exprés d'aquests o sigui necessari per imperatiu legal (Administracions públiques, Forces i Cossos de Seguretat de l'Estat, Ministeri Fiscal, Agència Espanyola de Protecció de Dades, etc).",
+      "DESCRIPTION_2": "UBIQ informa als Usuaris que les dades personals podran comunicar-se a proveïdors d'UBIQ per poder atendre a la gestió dels PREMIS ESLAND, cas en què aquells tindran la condició d'encarregats del tractament seguint les instruccions d'UBIC sobre el tractament de dades personals."
+    },
+    "USER_RIGHTS": {
+      "TITLE": "Drets dels usuaris",
+      "DESCRIPTION_1": "UBIQ informa als Usuaris que en referència al tractament de les seves dades personals poden exercir els drets següents:",
+      "ITEM_1": "Dret a revocar el consentiment atorgat en qualsevol moment.",
+      "ITEM_2": "Dret a obtenir informació sobre si UBIQ tracta dades personals de l'usuari.",
+      "ITEM_3": "Dret d'accés, rectificació, portabilitat i supressió de les vostres dades, ia la limitació o oposició al tractament.",
+      "ITEM_4": "Dret a no ser objecte de decisions individuals automatitzades, incloent-hi l'elaboració de perfils.",
+      "ITEM_5": "Dret a presentar una reclamació davant de l'Agència Espanyola de Protecció de Dades (www.aepd.es), quan l'Usuari consideri que UBIQ ha vulnerat els drets en el tractament de dades personals.",
+      "DESCRIPTION_2": "Els Usuaris podran exercir els seus drets en qualsevol moment i de forma gratuïta adreçant-se per escrit a UBIQ S.L.U. per correu postal a l'adreça de carrer Ganduxer, núm. 129, C.P 08022 Barcelona o bé mitjançant correu electrònic a l'adreça [… …info@fan.content.com…….], en tots dos casos caldrà acompanyar còpia del Document Nacional d'Identitat o document equivalent que acrediti la seva identitat."
+    },
+    "THIRD_PARTY_DOMAIN_LINKS": {
+      "TITLE": "Enllaços de domini de tercers",
+      "DESCRIPTION": "Per poder participar com a jurat els Usuaris seran redireccionats al domini www.twitch.tv titularitat d'un tercer -Twitch Interactive, Inc-. Aquest domini disposa de les seves pròpies Condicions d'Ús, Política de Privadesa i Política de Cookies. Per això, recomanem als Usuaris que les consultin abans de la seva utilització."
+    },
+    "SOCIALS": {
+      "TITLE": "Xarxes socials",
+      "DESCRIPTION_1": "Aquest Lloc Web pot contenir enllaços que permeten accedir a diferents xarxes socials pertanyents i gestionades per tercers (p.ex. Facebook, Instagram, YouTube). Aquests enllaços al Lloc Web tenen per únic objecte facilitar als Usuaris el accés a xarxes socials per a informals sobre els esdeveniments organitzats per UBIQ.",
+      "DESCRIPTION_2": "L'activació i ús d'aquestes aplicacions pot comportar la identificació i autenticació de l'Usuari (login/contrasenya) a les plataformes corresponents, completament externes al Lloc Web i fora del control d'UBIQ. Aquestes xarxes socials i plataformes disposen de les seves pròpies polítiques de privadesa i del tractament de les cookies. En aquest sentit, tota informació i dades personals que l'usuari proporcioni a aquestes plataformes serà sota la seva pròpia i exclusiva responsabilitat."
+    },
+    "COOKIES": {
+      "TITLE": "Cookies",
+      "DESCRIPTION_1": "Aquest Lloc Web no utilitza cookies per recollir informació dels Usuaris, únicament s'utilitzen cookies pròpies, de sessió, amb finalitat tècnica - aquelles que permeten a l'Usuari la navegació segura a través del Lloc Web i la utilització de les diferents funcions i serveis que s'ofereixen al Lloc Web. Per a una informació més detallada accediu a la Política de Cookies.",
+      "DESCRIPTION_2": "No obstant, aquest Lloc Web pot contenir enllaços a llocs web de tercers amb polítiques de privadesa i de cookies alienes a UBIQ i que l'Usuari podrà decidir si accepta o rebutja quan accedeixi a aquests llocs web."
+    },
+    "INTERNATIONAL_TRANSFERS": {
+      "TITLE": "Transferències internacionals",
+      "DESCRIPTION": "Les dades personals poden allotjar-se en servidors ubicats fora de l'Espai Econòmic Europeu (Estats Units, Japó, Austràlia, Japó), en participar als PREMIS ESLAND consent aquesta transferència de dades i se li informa que en aquestes es garanteix la existència d'una Decisió d'Adequació del Comitè Europeu de Protecció de Dades o bé l'adopció de mesures de garantia complementàries per tal de garantir un nivell d'adequació de protecció alineat amb el Reglament General de Protecció de Dades de la Unió Europea."
+    },
+    "MODIFICATIONS": {
+      "TITLE": "Modificacions de la política de privadesa",
+      "DESCRIPTION": "UBIQ es reserva el dret a modificar aquesta Política de privadesa en funció d'exigències legislatives, reglamentàries o amb la finalitat d'adaptar aquesta política a les instruccions dictades per l'Agència Espanyola de Protecció de Dades i/o pel Comitè Europeu de Protecció de Dades, per això s'aconsella als Usuaris que la visitin periòdicament. Quan es produeixin canvis significatius en aquesta Política, aquests es publicaran al Lloc Web.",
+      "LAST_UPDATE": "Data de la darrera actualització: 12 del 12 de 2023."
+    }
+  },
   "INFO": {
     "TITLE_HERO_1": "Els premis",
     "TITLE_HERO_2": "ESLAND",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -189,6 +189,89 @@
       ]
     }
   },
+  "PRIVACY": {
+    "POLICY": {
+      "TITLE": "Política de privacidad",
+      "DESCRIPTION_1": "Nos complace que visite la web oficial de PREMIOS ESLAND www.premiosesland.com (en adelante, Sitio Web) y agradecemos su interés.",
+      "DESCRIPTION_2": "UBIQ S.L.U (en adelante, UBIQ) tiene el firme compromiso de cumplir con la legislación vigente en materia de protección de datos personales para garantizar la privacidad, el secreto y la seguridad de los datos personales de los Usuarios aplicando medidas técnicas y organizativas apropiadas al efecto.",
+      "DESCRIPTION_3": "La presente Política de Privacidad tiene por objeto informar a los Usuarios sobre el tratamiento que UBIQ hace de los datos personales que el Usuario facilite al acceder, navegar y utilizar los servicios que se ofrecen en el Sitio Web, así como de las medidas de seguridad adoptadas, del ejercicio de los derechos de los Usuarios y de la forma de contacto.",
+      "DESCRIPTION_4": "Los datos personales sólo serán obtenidos por UBIQ para su tratamiento, cuando sean adecuados, pertinentes y no excesivos en relación con el ámbito y las finalidades determinadas, explícitas y legítimas para las que se hayan obtenido.",
+      "DESCRIPTION_5": "A continuación, cumplimiento con la normativa vigente en materia de protección de datos personales proporcionamos a los Usuarios la siguiente información:"
+    },
+    "RESPONSIBLE": {
+      "TITLE": "Responsable del tratamiento",
+      "DESCRIPTION_1": "UBIQ S.L.U (en adelante, UBIQ) sociedad andorrana con NRT L-718097-X, con domicilio social en la calle Josep Viladomat, 4, Ed Sogas, 1-1 AD700 Escaldes Engordany (Andorra), inscrita en el Registro de Sociedades del Gobierno de Andorra con nº 23023, con correo electrónico [info@ubiq.ad………….], es la titular de la página Web www.premiosesland.com (en adelante, Sitio Web).",
+      "DESCRIPTION_2": "Los Usuarios pueden contactar con el Responsable del Tratamiento a través de la siguiente dirección de correo electrónico: info@ubiq.ad"
+    },
+    "DEFINITIONS": {
+      "TITLE": "Definiciones",
+      "DESCRIPTION": "A los efectos de la presente Política, los siguientes términos tendrán el significado que se indica a continuación:",
+      "ITEM_1": "“Datos Personales”: toda información sobre una persona física identificada o identificable. Se considera persona física identificable toda persona cuya identidad pueda determinarse, directa o indirectamente, mediante un identificador.",
+      "ITEM_2": "“Responsable del Tratamiento”: Persona física o jurídica, autoridad pública, servicio u otro organismo que, solo o junto con otros, determine los fines y medios del tratamiento de datos.",
+      "ITEM_3": "“Encargado del Tratamiento”: Persona física o jurídica, autoridad pública, servicio u otro organismo que trate datos personales por cuenta del responsable del tratamiento.",
+      "ITEM_4": "“Interesado-Usuario”: Toda persona física identificada o identificable cuyos datos personales sean objeto de tratamiento.",
+      "ITEM_5": "“Tratamiento de datos”: Cualquier operación o conjunto de operaciones realizadas sobre Datos Personales o conjuntos de datos personales, ya sea por procedimientos automatizados o no, como la recogida, registro, organización, estructuración, conservación, adaptación o modificación, extracción, consulta, utilización, comunicación por transmisión, difusión o cualquier otra forma de habilitación de acceso, cotejo o interconexión, limitación, supresión o destrucción."
+    },
+    "PURPOSE": {
+      "TITLE": "Finalidad del tratamiento",
+      "DESCRIPTION_1": "Gestionar las solicitudes de información recibidas a través de la función de “Contacto” de la Web. Gestionar las votaciones de los PREMIOS ESLAND realizadas por los Usuarios del Sitio Web (identificación, validación y recuento de votos). Fines estadísticos de participación y resultados de las votaciones en los PREMIOS ESLAND -para dar cumplimiento a esta finalidad los datos personales serán objeto de un proceso de anonimización-. Para poder participar como jurado en los PREMIOS ESLAND, los Usuarios deberán pulsar en “Identifícate y Vota” y serán redireccionados a la web de Twitch (www.twitch.tv) en la que deberán disponer de una cuenta abierta en dicha plataforma de streaming. Cuando el Usuario desde su cuenta pulse “Autorizar” estará manifestando que ha leído y que acepta la Política de Privacidad de www.premiosesland.com. A continuación, el Usuario podrá seleccionar sus preferencias de voto de entre las distintas categorías definidas por Streamers y contenidos siguiendo las indicaciones del Sitio Web y una vez seleccionados sus votos deberá pulsar en “Enviar Mis Votos”. Las votaciones y la identidad del Usuario se registrarán en la base de datos de UBIQ. La identidad del Usuario se registrará mediante un código hash -algoritmo matemático- (pseudonimizado).",
+      "DESCRIPTION_2": "Twitch Interactive, Inc. propietaria de www.twitch.tv actúa como proveedor de los servicios de validación y verificación de la identidad de los Usuarios que votan para evitar el fraude en el proceso de votación."
+    },
+    "PERSONAL_DATA": {
+      "TITLE": "Categoría de datos personales",
+      "DESCRIPTION_1": "La categoría de datos que trata UBIQ en el Sitio Web, son:",
+      "DESCRIPTION_2": "Correo electrónico en función de Contacto. Datos identificativos: Identificación del Usuario mediante un código hash -algoritmo matemático-. UBIQ no accede a los datos de la cuenta que los Usuarios tienen en www.twitch.tv."
+    },
+    "LEGITIMACY": {
+      "TITLE": "Base de legitimación",
+      "DESCRIPTION_1": "La base de legitimación para gestionar las comunicaciones que se reciban a través de la función “Contacto” es el interés legítimo de UBIQ.",
+      "DESCRIPTION_2": "La base de legitimación del tratamiento de los datos personales de los Usuarios que participan en los PREMIOS ESLAND es el consentimiento expreso otorgado al participar como jurado y el interés legítimo de UBIQ en la gestión de los eventos que organice y en la gestión de los PREMIOS ESLAND.",
+      "DESCRIPTION_3": "El Usuario podrá revocar el consentimiento en cualquier momento. No obstante, el tratamiento sobre los datos personales realizado con anterioridad a la revocación del consentimiento será lícito."
+    },
+    "PRESERVATION": {
+      "TITLE": "Conservación de los datos",
+      "DESCRIPTION_1": "Los datos se conservarán durante el plazo estrictamente necesario para dar cumplimiento a la finalidad para la que fueron recabados. No obstante, UBIQ podrá conservar los datos para su puesta a disposición de las autoridades competentes o para hacer frente a posibles reclamaciones, en cuyo caso los datos se conservarán bloqueados hasta la finalización de los plazos de prescripción, momento en que serán eliminados con las medidas de seguridad adecuadas.",
+      "DESCRIPTION_2": "Finalizado el plazo de conservación, los datos personales podrán ser objeto de un proceso de anonimización para fines estadísticos de los PREMIOS ESLAND."
+    },
+    "COMMUNICATION": {
+      "TITLE": "Comunicación de datos",
+      "DESCRIPTION_1": "UBIQ no cederá a terceros los datos facilitados por los Usuarios del Sitio Web, salvo consentimiento previo y expreso de éstos o sea necesario por imperativo legal (Administraciones públicas, Fuerzas y Cuerpos de Seguridad del Estado, Ministerio Fiscal, Agencia Española de Protección de Datos, etc).",
+      "DESCRIPTION_2": "UBIQ informa a los Usuarios que los datos personales podrán comunicarse a proveedores de UBIQ para poder atender a la gestión de los PREMIOS ESLAND, en cuyo caso, aquellos tendrán la condición de encargados del tratamiento siguiendo las instrucciones de UBIQ sobre el tratamiento de datos personales."
+    },
+    "USER_RIGHTS": {
+      "TITLE": "Derechos de los usuarios",
+      "DESCRIPTION_1": "UBIQ informa a los Usuarios que en referencia al tratamiento de sus datos personales pueden ejercer los siguientes derechos:",
+      "ITEM_1": "Derecho a revocar el consentimiento otorgado en cualquier momento.",
+      "ITEM_2": "Derecho a obtener información sobre si UBIQ trata datos personales del Usuario.",
+      "ITEM_3": "Derecho de acceso, rectificación, portabilidad y supresión de sus datos, y a la limitación u oposición al tratamiento.",
+      "ITEM_4": "Derecho a no ser objeto de decisiones individuales automatizadas, incluyendo la elaboración de perfiles.",
+      "ITEM_5": "Derecho a presentar una reclamación ante el Agencia Española de Protección de Datos (www.aepd.es), cuando el Usuario considere que UBIQ ha vulnerado sus derechos en el tratamiento de datos personales.",
+      "DESCRIPTION_2": "Los Usuarios podrán ejercer sus derechos en cualquier momento y de forma gratuita dirigiéndose por escrito a UBIQ S.L.U. por correo postal a la dirección de calle Ganduxer, nº 129, C.P 08022 Barcelona o bien mediante correo electrónico a la dirección [……info@fan.content.com…….], en ambos casos deberá acompañarse copia del Documento Nacional de Identidad o documento equivalente que acredite su identidad."
+    },
+    "THIRD_PARTY_DOMAIN_LINKS": {
+      "TITLE": "Enlaces de dominio de terceros",
+      "DESCRIPTION": "Para poder participar como jurado los Usuarios serán redireccionados al dominio www.twitch.tv titularidad de un tercero -Twitch Interactive, Inc-. Dicho dominio dispone de sus propias Condiciones de Uso, Política de Privacidad y Política de Cookies. Por ello, recomendamos a los Usuarios que las consulten antes de su utilización."
+    },
+    "SOCIALS": {
+      "TITLE": "Redes sociales",
+      "DESCRIPTION_1": "Este Sitio Web puede contener enlaces que permiten acceder a diferentes redes sociales pertenecientes y gestionadas por terceros (p.ej. Facebook, Instagram, YouTube). Estos enlaces en el Sitio Web tienen por único objeto facilitar a los Usuarios el acceso a redes sociales para informales sobre los eventos organizados por UBIQ.",
+      "DESCRIPTION_2": "La activación y uso de estas aplicaciones puede conllevar la identificación y autenticación del Usuario (login/contraseña) en las plataformas correspondientes, completamente externas al Sitio Web y fuera del control de UBIQ. Dichas redes sociales y plataformas disponen de sus propias políticas de privacidad y del tratamiento de las cookies. En este sentido, toda información y datos personales que el Usuario proporcione a estas plataformas será bajo su propia y exclusiva responsabilidad."
+    },
+    "COOKIES": {
+      "TITLE": "Cookies",
+      "DESCRIPTION_1": "Este Sitio Web no utiliza cookies para recoger información de los Usuarios, únicamente se utilizan cookies propias, de sesión, con finalidad técnica - aquellas que permiten al Usuario la navegación segura a través del Sitio Web y la utilización de las distintas funciones y servicios que se ofrecen en el Sitio Web. Para una información más detallada acceda a la Política de Cookies.",
+      "DESCRIPTION_2": "No obstante, este Sitio Web puede contener enlaces a sitios web de terceros con políticas de privacidad y de cookies ajenas a UBIQ y que el Usuario podrá decidir si acepta o rechaza cuando acceda a esos sitios web."
+    },
+    "INTERNATIONAL_TRANSFERS": {
+      "TITLE": "Transferencias internacionales",
+      "DESCRIPTION": "Los datos personales pueden alojarse en servidores ubicados fuera del Espacio Económico Europeo (Estados Unidos, Japón, Australia, Japón), al participar en los PREMIOS ESLAND consiente dicha transferencia de datos y se le informa que en éstas se garantiza la existencia de una Decisión de Adecuación del Comité Europeo de Protección de Datos o bien la adopción de medidas de garantía complementarias a fin de garantizar un nivel de adecuación de protección alineado con el Reglamento General de Protección de Datos de la Unión Europea."
+    },
+    "MODIFICATIONS": {
+      "TITLE": "Modificaciones de la política de privacidad",
+      "DESCRIPTION": "UBIQ se reserva el derecho a modificar esta Política de privacidad en función de exigencias legislativas, reglamentarias o con la finalidad de adaptar dicha política a las instrucciones dictadas por la Agencia Española de Protección de Datos y/o por el Comité Europeo de Protección de Datos, por ello se aconseja a los Usuarios que la visiten periódicamente. Cuando se produzcan cambios significativos en esta Política, éstos se publicarán en el Sitio Web.",
+      "LAST_UPDATE": "Fecha de la última actualización: 12 del 12 de 2023."
+    }
+  },
   "INFO": {
     "TITLE_HERO_1": "Los premios",
     "TITLE_HERO_2": "ESLAND",

--- a/src/pages/ca/privacidad.astro
+++ b/src/pages/ca/privacidad.astro
@@ -1,0 +1,5 @@
+---
+import PrivacidadPage from "@/components/pages/Privacidad.astro"
+---
+
+<PrivacidadPage />

--- a/src/pages/privacidad.astro
+++ b/src/pages/privacidad.astro
@@ -1,0 +1,5 @@
+---
+import PrivacidadPage from "@/components/pages/Privacidad.astro"
+---
+
+<PrivacidadPage />


### PR DESCRIPTION
This will add access to the _Privacidad_ page for both Spanish and Catalan languages. Bear in mind that Catalan translation was made using Google Translate, might be wise to have a native speaker check out the translation on the corresponding i18n file.

All content comes from the original esland website, but with the same styles from the _Cookies_ legal section. The page follows semantic HTML guidelines (sections with their own headings inside a `main` tag).

![t2saJa9eEV](https://github.com/midudev/esland-web/assets/23394743/90469c68-51a4-4ce2-8076-0303e51df286)
