### PR TITLE
fix: scroll caused by animation in info page

### DIFF
--- a/src/components/pages/Info.astro
+++ b/src/components/pages/Info.astro
@@ -108,7 +108,7 @@ const i18n = getI18N({ currentLocale })
   @keyframes entry-animation {
     0% {
       opacity: 0;
-      translate: -100px 0;
+      translate: var(--entry-animation) 0;
     }
     100% {
       opacity: 1;
@@ -118,7 +118,7 @@ const i18n = getI18N({ currentLocale })
   @keyframes cover-animation {
     0% {
       opacity: 0;
-      translate: 100px 0;
+      translate: var(--cover-animation) 0;
     }
     100% {
       opacity: 1;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -40,6 +40,15 @@ const { currentLocale } = Astro
     <style is:global>
       :root {
         color-scheme: dark;
+        --entry-animation: -20px;
+        --cover-animation: 20px;
+      }
+
+      @media (min-width: 1400px) {
+        :root {
+          --entry-animation: -100px;
+          --cover-animation: 100px;
+        }
       }
 
       @font-face {


### PR DESCRIPTION
Actualmente en la página de info al hacer el translate tan "grande" provoca un scroll en la página y el menú no se ve hasta abajo:
<img width="517" alt="Captura de pantalla 2024-01-15 a las 20 33 16" src="https://github.com/midudev/esland-web/assets/11647193/99f686e8-c9bf-46ce-a5d7-e6aedde698a1">
<img width="457" alt="Captura de pantalla 2024-01-15 a las 20 33 35" src="https://github.com/midudev/esland-web/assets/11647193/a8844dd0-544a-482c-ad6f-d2a8edd9761f">
<img width="471" alt="Captura de pantalla 2024-01-15 a las 20 33 45" src="https://github.com/midudev/esland-web/assets/11647193/3898bd8c-2650-4f68-9645-a0861c35e9c3">

Si se hace un overflow-x-hidden se pierde la animación. 

He agregado un media query para que el efecto sea mas acentuado en resoluciones mas grande pero en resolución tablet/móvil ese efecto se aprecie algo pero no sea tan "exagerado", así quedaría después del arreglo:
<img width="493" alt="Captura de pantalla 2024-01-15 a las 20 35 17" src="https://github.com/midudev/esland-web/assets/11647193/3a67e74a-d383-49f2-b46e-e2195fed0155">

<img width="463" alt="Captura de pantalla 2024-01-15 a las 20 35 08" src="https://github.com/midudev/esland-web/assets/11647193/1dd318f2-a327-4f9c-bce6-468965f24010">

