### PR TITLE
Add zod validation to votes

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "photoswipe": "5.4.3",
     "preact": "10.19.3",
     "tailwindcss": "3.4.1",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/bun": "1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ dependencies:
   typescript:
     specifier: 5.3.3
     version: 5.3.3
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
 
 devDependencies:
   '@types/bun':

--- a/src/pages/api/vote.ts
+++ b/src/pages/api/vote.ts
@@ -1,6 +1,7 @@
 import { addUserVotes, cleanUserVotes } from "@/db/client";
 import { type APIRoute } from "astro";
 import { getSession } from "auth-astro/server";
+import { votesSchema } from '@/schemas/votes.ts';
 
 export const POST: APIRoute = async ({ request }) => {
   const session = await getSession(request)
@@ -18,8 +19,7 @@ export const POST: APIRoute = async ({ request }) => {
   let votesToSave = []
   try {
     const { votes } = await request.json()
-    // validar la estructura de los votos
-    // se podría hacer con zod
+    votesSchema.parse(votes)
     votesToSave = votes
   } catch (e) {
     return new Response('Bad Request', { status: 400 })

--- a/src/schemas/votes.ts
+++ b/src/schemas/votes.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod'
+
+export const votesSchema = z.array(z.string().regex(/^\d\d?-\d\d?$/).array().length(4))


### PR DESCRIPTION
This will create a new schema file for parsing a user's vote request structure and parse the votes submitted to the api. It checks that the votes field is an array made up of a series of arrays of strings in the form 'xx-xx' (x being digits, with the second one being optional) for each category. It also checks that there's exactly four votes.

Take into account that this schema can't validate that the given option id is a valid one, only its format. More information would be necessary for that, but at that point I'd change the votes structure.