### PR TITLE
Add script for SQL INSERT statements for voting categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "prettier --write  \"**/*.{js,jsx,ts,tsx,md,mdx,astro}\" && eslint --fix \"src/**/*.{js,ts,jsx,tsx,astro}\"",
     "script:create-thumbs": "bun ./scripts/create-thumbnails-gallery.ts",
     "script:create-meta": "bun ./scripts/create-meta-from-gallery.ts",
+    "script:create-vote-inserts": "bun ./scripts/create-vote-inserts.ts",
     "webp": "bun ./scripts/convert-all.ts",
     "dl": "bun ./scripts/download-all-images.ts",
     "dl:voting": "bun ./scripts/dl-voting.ts"

--- a/scripts/create-vote-inserts.ts
+++ b/scripts/create-vote-inserts.ts
@@ -1,0 +1,30 @@
+import { join } from 'node:path'
+
+const editionsVotesFilePath = process.argv[2]
+if (editionsVotesFilePath === undefined) {
+  console.error('Must provide editions file path')
+  process.exit(1)
+}
+
+const editionsVotesFile = Bun.file(editionsVotesFilePath)
+const votes: [{
+  categoria: string,
+  candidatos: [{ nombre: string, imagen: string, enlace: string, id: string }],
+  id: string
+}] = JSON.parse(await editionsVotesFile.text())
+const inserts: string[] = []
+
+votes.forEach(({ categoria: categoryName, candidatos: categoryCandidates, id: categoryId }) => {
+  inserts.push(
+    `INSERT INTO Categories (category_id, category_name) VALUES ("${categoryId}", "${categoryName}")`
+  )
+  categoryCandidates.forEach((candidate) => {
+    const { id: candidateId, nombre: candidateName } = candidate
+    inserts.push(
+      `INSERT INTO Options (option_id, category_id, option_name) VALUES ("${candidateId}", "${categoryId}", "${candidateName}")`
+    )
+  })
+})
+
+const outputPath = join(process.cwd(), 'src/data/vote-inserts.sql')
+await Bun.write(outputPath, inserts.join('\n'))

--- a/scripts/create-vote-inserts.ts
+++ b/scripts/create-vote-inserts.ts
@@ -9,7 +9,7 @@ if (editionsVotesFilePath === undefined) {
 const editionsVotesFile = Bun.file(editionsVotesFilePath)
 const votes: [{
   categoria: string,
-  candidatos: [{ nombre: string, imagen: string, enlace: string, id: string }],
+  candidatos: { nombre: string, imagen: string, enlace: string, id: string }[],
   id: string
 }] = JSON.parse(await editionsVotesFile.text())
 const inserts: string[] = []


### PR DESCRIPTION
This will add the `scripts/create-vote-inserts.ts` file and its corresponding script entry in `package.json` for creating a SQL file containing the insert statements for the provided vote categories and candidates of a given edition.

For example, the command `bun run script:create-vote-inserts "src/data/editions-vote.json"` will output the file `src/data/vote-inserts.sql` with the corresponding insert statements for setting up the vote system database.

When next editions are added, one could set up its corresponding json file and run this script to generate its complementary SQL file to be fed to the database.

When Midu had to go through making a script for this while live I thought "why not make it a PR?". So here it is 🤩