### PR TITLE
Fixed the 404 error in the "Aviso Legal" page in Catalan and added the CA links to the footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -72,18 +72,20 @@ const i18n = getI18N({ currentLocale })
           </h2>
           <ul class="flex flex-col gap-2 font-medium text-gray-400">
             <li>
-              <a
+              <Link
                 href="/aviso-legal"
                 class="hover:underline hover:text-primary duration-300"
-                >{i18n.FOOTER.LEGAL.NOTICE}</a
-              >
+                >
+                {i18n.FOOTER.LEGAL.NOTICE}
+              </Link>
             </li>
             <li>
-              <a
+              <Link
                 href="/privacidad"
                 class="hover:underline hover:text-primary duration-300"
-                >{i18n.FOOTER.LEGAL.PRIVACY}</a
-              >
+                >
+                {i18n.FOOTER.LEGAL.PRIVACY}
+              </Link>
             </li>
             <li>
               <Link
@@ -101,25 +103,28 @@ const i18n = getI18N({ currentLocale })
           </h2>
           <ul class="flex flex-col gap-2 font-medium text-gray-400">
             <li>
-              <a
+              <Link
                 href="/"
                 class="hover:underline hover:text-primary duration-300"
-                >{i18n.FOOTER.WEB_MAP.HOME}</a
-              >
+                >
+                {i18n.FOOTER.WEB_MAP.HOME}
+              </Link>
             </li>
             <li>
-              <a
+              <Link
                 href="/info"
                 class="hover:underline hover:text-primary duration-300"
-                >{i18n.FOOTER.WEB_MAP.INFO}</a
-              >
+                >
+                {i18n.FOOTER.WEB_MAP.INFO}
+            </Link>
             </li>
             <li>
-              <a
+              <Link
                 href="/archivo"
                 class="hover:underline hover:text-primary duration-300"
-                >{i18n.FOOTER.WEB_MAP.ARCHIVE}</a
-              >
+                >
+                {i18n.FOOTER.WEB_MAP.ARCHIVE}
+              </Link>
             </li>
           </ul>
         </div>

--- a/src/pages/ca/aviso-legal.astro
+++ b/src/pages/ca/aviso-legal.astro
@@ -1,0 +1,5 @@
+---
+import LegalNotice from '@/components/pages/LegalNotice.astro'
+---
+
+<LegalNotice />


### PR DESCRIPTION
Added "legal notice" page in /ca/ to fix 404 error when selecting Catalan language. Also added links to footer to point to links in catalan version "/ca/".

Before:
![image](https://github.com/midudev/esland-web/assets/22538431/53a534ea-18d6-460c-9487-fcbaf73b1447)

 After:
![image](https://github.com/midudev/esland-web/assets/22538431/80d77ce9-caee-4939-8911-eeb3b1a44321)


