### PR TITLE
Fix horizontal scroll in info page

### DIFF
--- a/src/components/InfoKitPrensa.astro
+++ b/src/components/InfoKitPrensa.astro
@@ -5,7 +5,7 @@ const { currentLocale } = Astro
 const i18n = getI18N({ currentLocale })
 ---
 
-<section class="flex flex-col items-center justify-center p-4">
+<section class="flex flex-col items-center justify-center p-4 overflow-hidden">
   <h2 class="text-6xl font-bold mb-14 mt-4">{i18n.MEDIA_KIT_TITLE}</h2>
   <div class="flex flex-col gap-16 lg:flex-row lg:gap-8">
     <InfoKitPrensaItem


### PR DESCRIPTION
The hover of the images causes an annoying horizontal scroll, adding overflow hidden to the section that surrounds them, we maintain the effect without causing overflow.

![esland_info](https://github.com/midudev/esland-web/assets/34165518/c3118259-f156-43ba-ac95-c77fcd17b665)
