### PR TITLE
Added translations to 404 Error Page & routes to homepage for each lang

### DIFF
--- a/src/components/pages/Error404.astro
+++ b/src/components/pages/Error404.astro
@@ -4,12 +4,16 @@ import LogoTitle from "@/components/LogoTitle.astro";
 import { getI18N } from "@/i18n"
 import styles from "@/components/styles/Button.module.css"
 
+import { getLangFromUrl, useTranslatedPath } from "@/i18n/utils";
+
 const { currentLocale } = Astro;
 const i18n = getI18N({ currentLocale })
 
+const lang = getLangFromUrl(Astro.url);
+const translatePath = useTranslatedPath(lang);
+
 ---
-<!-- En espera a traducir en caso de aceptar la PR de los path/routing traducidos, que también toqué los json -->
-<Error404Layout title="404 - Página no encontrada - Esland" description="Error 404">
+<Error404Layout title={i18n.SEO.ERROR_404_TITLE} description={i18n.SEO.ERROR_404_DESCRIPTION}>
         <section
         class="flex relative pb-24 min-h-screen"
         >
@@ -20,11 +24,10 @@ const i18n = getI18N({ currentLocale })
                         404
                     </h1>
                     <p class="text-white text-[10px] md:text-xs text-center uppercase mt-2 ">
-                        <!-- En espera a traducir en caso de aceptar la PR de los path/routing traducidos, que también toqué los json -->
-                        PÁGINA NO ENCONTRADA
+                        {i18n.ERROR_404.TITLE}
                     </p>
                 </div>
-                <a href="/" class={`
+                <a href={translatePath('/')} class={`
                   hover:text-cyan-100
                     text__glowing
                     text-sm 
@@ -39,7 +42,7 @@ const i18n = getI18N({ currentLocale })
                     border-white
                     rounded-full
                     uppercase`}>
-                     Volver a la página de inicio
+                     {i18n.ERROR_404.BACK_HOMEPAGE_BTN}
                 </a> 
             </div>
         </section>

--- a/src/i18n/ca.json
+++ b/src/i18n/ca.json
@@ -7,7 +7,9 @@
 		"INFO_TITLE": "Informació - Premis ESLAND 2024",
 		"INFO_DESCRIPTION": "Descobreix tot el que necessites saber sobre els Premis ESLAND 2024 i descarrega el Kit de Premsa",
 		"VOTE_TILTE": "Vota pels teus creadors de contingut favorits - Premis ESLAND 2024",
-		"VOTE_DESCRIPTION": "Vota pels teus creadors de contingut favorits d'Espanya, Llatinoamèrica i Andorra"
+		"VOTE_DESCRIPTION": "Vota pels teus creadors de contingut favorits d'Espanya, Llatinoamèrica i Andorra",
+		"ERROR_404_TITLE": "404 Pàgina no trobada - Premis ESLAND 2024",
+		"ERROR_404_DESCRIPTION": "Pàgina no trobada (Error 404). Verifica la URL o explora les nostres seccions. Necessites ajuda? Contacta'ns."
 	},
 	"HEADER": {
 		"LOGO": "Tornar a la pàgina d'inici dels Premis ESLAND"
@@ -383,5 +385,9 @@
 		"MODIFICATIONS": {
 			"LAST_UPDATE": "Fecha de la última actualización: 12 del 12 de 2023."
 		}
+	},
+	"ERROR_404": {
+		"TITLE": "Pàgina no trobadaa",
+		"BACK_HOMEPAGE_BTN": "Tornar a la pàgina d'inici"
 	}
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -7,7 +7,9 @@
 		"INFO_TITLE": "Information - ESLAND Awards 2024",
 		"INFO_DESCRIPTION": "Learn everything you need to know about the ESLAND Awards 2024 and download the Press Kit.",
 		"VOTE_TITLE": "Vote for Your Favorite Content Creators - ESLAND Awards 2024",
-		"VOTE_DESCRIPTION": "Support your favorite content creators from Spain, Latin America, and Andorra by voting for them."
+		"VOTE_DESCRIPTION": "Support your favorite content creators from Spain, Latin America, and Andorra by voting for them.",
+		"ERROR_404_TITLE": "404 Page not found - ESLAND Awards 2024",
+		"ERROR_404_DESCRIPTION": "Page not found (Error 404). Check the URL or explore our sections. Need help? Contact us."
 	},
 	"HEADER": {
 		"LOGO": "Return to the ESLAND Awards Homepage"
@@ -365,5 +367,9 @@
 		"MODIFICATIONS": {
 			"LAST_UPDATE": "Date of last update: 12 del 12 de 2023."
 		}
+	},
+	"ERROR_404": {
+		"TITLE": "Page not found",
+		"BACK_HOMEPAGE_BTN": "Back to homepage"
 	}
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -7,7 +7,9 @@
 		"INFO_TITLE": "Información - Premios ESLAND 2024",
 		"INFO_DESCRIPTION": "Descubre todo lo que necesitas saber sobre los Premios ESLAND 2024 y descarga el Kit de Prensa",
 		"VOTE_TITLE": "Vota por tus creadores de contenido favoritos - Premios ESLAND 2024",
-		"VOTE_DESCRIPTION": "Vota por tus creadores de contenido favoritos de España, Latinoamérica y Andorra"
+		"VOTE_DESCRIPTION": "Vota por tus creadores de contenido favoritos de España, Latinoamérica y Andorra",
+		"ERROR_404_TITLE": "404 Página no encontrada - Premios ESLAND 2024",
+		"ERROR_404_DESCRIPTION": "404 Página no encontrada - Premios ESLAND 2024"
 	},
 	"HEADER": {
 		"LOGO": "Volver a la página de inicio de los Premios ESLAND"
@@ -383,5 +385,9 @@
 		"MODIFICATIONS": {
 			"LAST_UPDATE": "Fecha de la última actualización: 12 del 12 de 2023."
 		}
+	},
+	"ERROR_404": {
+		"TITLE": "Página no encontrada",
+		"BACK_HOMEPAGE_BTN": "Volver a la página de inicio"
 	}
 }

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -60,7 +60,7 @@ export const ui = {
 export const routes = {
 	es: {
 		vota: 'vota',
-		info: 'informacion',
+		info: 'info',
 		archivo: 'archivo',
 		'aviso-legal': 'aviso-legal',
 		privacidad: 'privacidad',


### PR DESCRIPTION
Added:
- JSON Translations to 404 Error Page 
- Routes to homepage for each lang

Fix:
 - Small issue fixed on spanish info page routing in ui.ts


Before:
![error404-esland-translate-before](https://github.com/midudev/esland-web/assets/128867199/b9f6498c-7c53-4169-be37-22820b0353e8)


After:
![error404-esland-translate-after-1](https://github.com/midudev/esland-web/assets/128867199/2ddc37aa-82ec-4275-ab81-3e6419485986)

