### PR TITLE
Change h1 to div in Video component

### DIFF
--- a/src/components/Video.astro
+++ b/src/components/Video.astro
@@ -20,7 +20,7 @@ const i18n = getI18N({ currentLocale })
     <section
       class="absolute z-10 animate-fade-up flex justify-center items-center gap-8 flex-col"
     >
-      <h1
+      <div
         class="flex items-center gap-5 text-4xl md:text-6xl lg:gap-20 lg:text-8xl font-tomaso"
       >
         <span>E</span>
@@ -32,7 +32,7 @@ const i18n = getI18N({ currentLocale })
         />
         <span>N</span>
         <span>D</span>
-      </h1>
+      </div>
 
       <p
         class="subtitle text-xl lg:text-2xl text-center text-wrap font-jura px-4"


### PR DESCRIPTION
In the home page there are 2 H1 tags.

With this PR we leave only one H1, modifying the H1 tag of the video component to div and leaving the most descriptive one.

<img width="674" alt="image" src="https://github.com/midudev/esland-web/assets/25681494/4f48532a-066f-40b9-81b6-7964a3bf1d5e">
